### PR TITLE
Implemented No CPU Copy for NVENC

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,28 +1,18 @@
-name: Deploy Rust Documentation
-
+name: Clippy Check
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 jobs:
-  build:
+  clippy:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-
+      
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -30,7 +20,7 @@ jobs:
         components: clippy
         profile: minimal
         override: true
-
+        
     - name: Install system dependencies
       run: |
         sudo apt-get update
@@ -60,30 +50,13 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
+          ${{ runner.os }}-cargo-clippy-
           ${{ runner.os }}-cargo-
-
-    - name: Build documentation
-      run: |
-        cargo doc --no-deps --document-private-items --all-features
-        echo '<meta http-equiv="refresh" content="0; url=./waycap_rs/">' > target/doc/index.html
-
-    - name: Setup Pages
-      uses: actions/configure-pages@v4
-
-    - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
-      with:
-        path: './target/doc'
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v4
+          
+    - name: Run Clippy
+      run: cargo clippy --all-targets --all-features -- -D warnings
+      
+    - name: Run Clippy (tests)
+      run: cargo clippy --tests --all-features -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "waycap-rs"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "bytemuck",
  "ctrlc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +16,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "aligned-vec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
 
 [[package]]
 name = "annotate-snippets"
@@ -37,6 +49,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +87,29 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "av1-grain"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3efb2ca85bc610acfa917b5aaa36f3fcbebed5b3182d7f877b02531c4b80c8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98922d6a4cfbcb08820c69d8eeccc05bb1f29bfa06b4f5b1dbfe9a868bd7608e"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "bindgen"
@@ -93,6 +151,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit_field"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,10 +169,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
+name = "bitstream-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
+
+[[package]]
+name = "built"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
+
+[[package]]
+name = "bumpalo"
+version = "3.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+
+[[package]]
 name = "bytemuck"
 version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cc"
@@ -116,6 +204,8 @@ version = "1.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -151,6 +241,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cgl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +276,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,10 +300,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "ctrlc"
@@ -207,7 +346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
 dependencies = [
  "nix 0.30.1",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -233,6 +372,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "drm-fourcc"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +413,30 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "exr"
+version = "1.73.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83197f59927b46c04a183a619b7c29df34e63e63c7869320862268c0ef687e0"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "ffmpeg-next"
@@ -273,6 +461,16 @@ dependencies = [
  "num_cpus",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -372,7 +570,49 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "gif"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "gl"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94edab108827d67608095e269cf862e60d920f144a5026d3dbcfd8b877fb404"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
 ]
 
 [[package]]
@@ -380,6 +620,70 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "glutin"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg_aliases",
+ "cgl",
+ "dispatch2",
+ "glutin_egl_sys",
+ "glutin_glx_sys",
+ "glutin_wgl_sys",
+ "libloading",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "once_cell",
+ "raw-window-handle",
+ "wayland-sys 0.31.6",
+ "windows-sys 0.52.0",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin_egl_sys"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4680ba6195f424febdc3ba46e7a42a0e58743f2edb115297b86d7f8ecc02d2"
+dependencies = [
+ "gl_generator",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "glutin_glx_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7bb2938045a88b612499fbcba375a77198e01306f52272e692f8c1f3751185"
+dependencies = [
+ "gl_generator",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -409,6 +713,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "image"
+version = "0.25.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db35664ce6b9810857a38a906215e75a9c879f0696556a39f59c62829710251a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "num-traits",
+ "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b77d01e822461baa8409e156015a1d91735549f0f2c17691bd2d996bef238f7f"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
+
+[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +759,17 @@ checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -437,6 +791,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
+
+[[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +833,12 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "lebe"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
@@ -464,10 +856,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "libloading"
-version = "0.8.7"
+name = "libfuzzer-sys"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
+checksum = "cf78f52d400cf2d84a3a973a78a592b4adc535739e0a5597a0da6f0c357adc75"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets 0.53.0",
@@ -508,16 +910,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "nix"
@@ -553,6 +1011,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,10 +1077,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88c6597e14493ab2e44ce58f2fdecf095a51f12ca57bec060a11c57332520551"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.9.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
@@ -615,6 +1184,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,6 +1242,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afbdc74edc00b6f6a218ca6a5364d6226a259d4b8ea1af4a0ea063f27e179f4d"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,6 +1283,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -695,7 +1317,83 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rav1e"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87ce80a7665b1cce111f8a16c1f3929f6547ce91ade6addf4ec86a8dda5ce9"
+dependencies = [
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.12.1",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "profiling",
+ "rand",
+ "rand_chacha",
+ "simd_helpers",
+ "system-deps",
+ "thiserror",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a5f31fcf7500f9401fea858ea4ab5525c99f2322cfcee732c0e6c74208c0c6"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -734,6 +1432,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rgb"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+
+[[package]]
 name = "ringbuf"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,6 +1453,18 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "serde"
@@ -784,6 +1500,21 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
 
 [[package]]
 name = "simple-logging"
@@ -888,6 +1619,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
+dependencies = [
+ "flate2",
+ "jpeg-decoder",
+ "weezl",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +1682,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "v_frame"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f32aaa24bacd11e488aa9ba66369c7cd514885742c9fe08cfe85884db3e92b"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,6 +1717,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "waycap-rs"
 version = "0.1.3"
 dependencies = [
@@ -971,13 +1791,87 @@ dependencies = [
  "ctrlc",
  "drm-fourcc",
  "ffmpeg-next",
+ "gl",
+ "glutin",
+ "image",
+ "khronos-egl",
  "libc",
+ "libloading",
  "log",
  "pipewire",
  "portal-screencast-waycap",
  "ringbuf",
  "simple-logging",
+ "wayland-client",
+ "wayland-sys 0.31.6",
 ]
+
+[[package]]
+name = "wayland-client"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3b068c05a039c9f755f881dc50f01732214f5685e379829759088967c46715"
+dependencies = [
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "libc",
+ "nix 0.24.3",
+ "scoped-tls",
+ "wayland-commons",
+ "wayland-scanner",
+ "wayland-sys 0.29.5",
+]
+
+[[package]]
+name = "wayland-commons"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8691f134d584a33a6606d9d717b95c4fa20065605f798a3f350d78dced02a902"
+dependencies = [
+ "nix 0.24.3",
+ "once_cell",
+ "smallvec",
+ "wayland-sys 0.29.5",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4303d8fa22ab852f789e75a967f0a2cdc430a607751c0499bada3e451cbd53"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "xml-rs",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be12ce1a3c39ec7dba25594b97b42cb3195d54953ddb9d3d95a7c3902bc6e9d4"
+dependencies = [
+ "dlib",
+ "pkg-config",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbcebb399c77d5aa9fa5db874806ee7b4eba4e73650948e8f93963f128896615"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "weezl"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
 
 [[package]]
 name = "winapi"
@@ -1000,6 +1894,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1148,6 +2051,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.0",
+]
+
+[[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
 name = "xml-rs"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,4 +2103,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e4a518c0ea2576f4da876349d7f67a7be489297cd77c2cf9e04c2e05fcd3974"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,7 +71,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -129,7 +138,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -147,7 +156,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -350,6 +359,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "cust"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6cc71911e179f12483b9734120b45bd00bf64fab085cc4818428523eedd469"
+dependencies = [
+ "bitflags 1.3.2",
+ "bytemuck",
+ "cust_core",
+ "cust_derive",
+ "cust_raw",
+ "find_cuda_helper",
+]
+
+[[package]]
+name = "cust_core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "039f79662cb8f890cbf335e818cd522d6e3a53fe63f61d1aaaf859cd3d975f06"
+dependencies = [
+ "cust_derive",
+ "glam",
+ "mint",
+ "vek",
+]
+
+[[package]]
+name = "cust_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3bc95fe629aed92b2423de6ccff9e40174b21d19cb6ee6281a4d04ac72f66"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "cust_raw"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf40d6ade12cb9828bbc844b9875c7b93d25e67a3c9bf61c7aa3ae09e402bf8"
+dependencies = [
+ "find_cuda_helper",
+]
+
+[[package]]
 name = "dbus"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +519,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "find_cuda_helper"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f9e65c593dd01ac77daad909ea4ad17f0d6d1776193fc8ea766356177abdad"
+dependencies = [
+ "glob",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,7 +593,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -613,6 +677,15 @@ dependencies = [
  "khronos_api",
  "log",
  "xml-rs",
+]
+
+[[package]]
+name = "glam"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -769,7 +842,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -876,6 +949,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
 name = "libspa"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +1039,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mint"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,7 +1119,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1064,6 +1149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1257,7 +1343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1455,6 +1541,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,6 +1560,12 @@ name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -1483,7 +1584,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1550,6 +1651,17 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
@@ -1604,7 +1716,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1705,6 +1817,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
+name = "vek"
+version = "0.15.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8085882662f9bc47fc8b0cdafa5e19df8f592f650c02b9083da8d45ac9eebd17"
+dependencies = [
+ "approx",
+ "num-integer",
+ "num-traits",
+ "rustc_version",
+]
+
+[[package]]
 name = "version-compare"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1747,7 +1871,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -1769,7 +1893,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1789,6 +1913,7 @@ version = "0.1.3"
 dependencies = [
  "bytemuck",
  "ctrlc",
+ "cust",
  "drm-fourcc",
  "ffmpeg-next",
  "gl",
@@ -2102,7 +2227,7 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,11 @@ pipewire = "0.8.0"
 portal-screencast-waycap = "1.0.0"
 ringbuf = "0.4.8"
 simple-logging = "2.0.2"
+gl = "0.14.0"
+glutin = "0.32.3"
+khronos-egl = { version = "6.0.0", features = ["dynamic"] }
+libloading = "0.8.8"
+# Outdated on purpose until I can figure out how to turn the wl_display into a ptr in 3x
+wayland-client = {version = "0.29.2", features = ["use_system_lib"] }
+wayland-sys = "0.31.6"
+image = "0.25.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waycap-rs"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 authors = ["Adonis Carvajal <adonis.carvajal2203@gmail.com>"]
 description = "High-level Wayland screen capture library with hardware-accelerated encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ libloading = "0.8.8"
 wayland-client = {version = "0.29.2", features = ["use_system_lib"] }
 wayland-sys = "0.31.6"
 image = "0.25.6"
+cust = "0.3.2"

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A high-level Wayland screen capture library with hardware-accelerated encoding f
 
 ## Features
 
-- **Hardware-accelerated video encoding** (Using VAAPI or NVenc)
+- **Hardware-accelerated video encoding** (Using VAAPI or NVENC)
 - **Audio capture** with Opus encoding
-- **Copy-Free** video encoding leveraging pipewire's DMA Buffers (For Vaapi only right now)
+- **Copy-Free** video encoding leveraging pipewire's DMA Buffers
 - **Multiple quality presets** for various use cases
 - **Cursor visibility control**
 - **Simple, ergonomic API** for easy integration
@@ -17,6 +17,7 @@ A high-level Wayland screen capture library with hardware-accelerated encoding f
 - XDG Desktop Portal
 - PipeWire
 - VA-API compatible hardware for VAAPI encoding
+- CUDA compatible hardware for NVENC encoding
 
 ## Installation
 
@@ -24,7 +25,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-waycap-rs = "0.1.0"
+waycap-rs = "0.2.0"
 ```
 
 ## Examples Usage
@@ -89,7 +90,6 @@ https://github.com/Adonca2203/WayCap
 Contributions are always welcome and encouraged, feel free to open a PR with any features you think may be missing.
 
 ### Currently I have planned adding the following:
-- **H264Nvenc** for more native NVIDIA hardware support.
 - Capturing more than system audio -- Support for microphones
 
 ### Areas for Improvement aside from the things already mentioned:
@@ -97,6 +97,7 @@ Contributions are always welcome and encouraged, feel free to open a PR with any
 - Documentation around the public facing APIs.
 - Bug Reports via github Issues
 - Platform Testing as I am currently limited by my hardware
+- Leverage the GpuVendor field of EGL to dynamically set the target encoder
 
 ## Pull Request Guidelines
 - **Fork the repository** based off the `main` branch.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rustc-link-lib=dylib=cuda");
+    println!("cargo:rustc-link-search=native=/usr/lib");
+}

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 fn main() {
+    // CUDA FFI bindings
     println!("cargo:rustc-link-lib=dylib=cuda");
     println!("cargo:rustc-link-search=native=/usr/lib");
 }

--- a/examples/record_and_save.rs
+++ b/examples/record_and_save.rs
@@ -1,0 +1,114 @@
+use std::{
+    collections::BTreeMap,
+    sync::{atomic::AtomicBool, Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+use ringbuf::traits::Consumer;
+use waycap_rs::{
+    pipeline::builder::CaptureBuilder,
+    types::{
+        config::{QualityPreset, VideoEncoder},
+        error::Result,
+        video_frame::EncodedVideoFrame,
+    },
+    Capture,
+};
+
+fn main() -> Result<()> {
+    simple_logging::log_to_stderr(log::LevelFilter::Debug);
+    log::info!("Simple Capture and Save Example");
+    log::info!("=====================");
+    log::info!("This example will capture your screen for 10 seconds");
+    log::info!("and save a file called example2.mp4 to the current directory");
+    log::info!("");
+    log::info!("Press Enter to start...");
+
+    // Wait for user input
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let mut capture = CaptureBuilder::new()
+        .with_quality_preset(QualityPreset::Medium)
+        .with_cursor_shown()
+        .with_video_encoder(VideoEncoder::H264Nvenc)
+        .build()?;
+
+    let mut video_recv = capture.take_video_receiver();
+
+    // Use a BTree Map so it is sorted by DTS
+    // needed like this for export time monotonic dts times
+    let encoded_video = Arc::new(Mutex::new(BTreeMap::<i64, EncodedVideoFrame>::new()));
+    let capture_clone = Arc::clone(&encoded_video);
+    let h1stop = Arc::clone(&stop);
+    let handle1 = std::thread::spawn(move || loop {
+        if h1stop.load(std::sync::atomic::Ordering::Acquire) {
+            break;
+        }
+
+        while let Some(encoded_frame) = video_recv.try_pop() {
+            capture_clone
+                .lock()
+                .unwrap()
+                .insert(encoded_frame.dts, encoded_frame);
+        }
+        std::thread::sleep(Duration::from_nanos(100));
+    });
+
+    log::info!("Starting 10-second capture...");
+    capture.start()?;
+
+    let start_time = Instant::now();
+    let capture_duration = Duration::from_secs(10);
+
+    while start_time.elapsed() < capture_duration {
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    log::info!("Capture complete! Stopping...");
+    stop.store(true, std::sync::atomic::Ordering::Release);
+
+    let _ = handle1.join();
+
+    log::info!("Writing output to example2.mp4");
+
+    save_buffer("example2.mp4", &encoded_video.lock().unwrap(), &capture)?;
+
+    Ok(())
+}
+
+fn save_buffer(
+    filename: &str,
+    video_buffer: &BTreeMap<i64, EncodedVideoFrame>,
+    capture: &Capture,
+) -> Result<()> {
+    let mut output = ffmpeg_next::format::output(&filename)?;
+
+    capture.with_video_encoder(|enc| {
+        if let Some(encoder) = enc {
+            let video_codec = encoder.codec().unwrap();
+            let mut video_stream = output.add_stream(video_codec).unwrap();
+            video_stream.set_time_base(encoder.time_base());
+            video_stream.set_parameters(encoder);
+        }
+    });
+
+    output.write_header()?;
+
+    for (_, frame) in video_buffer {
+        let mut packet = ffmpeg_next::codec::packet::Packet::copy(&frame.data);
+        log::info!("Data: {:?}", frame.data);
+        packet.set_pts(Some(frame.pts));
+        packet.set_dts(Some(frame.dts));
+
+        // We only have one stream (out video stream)
+        packet.set_stream(0);
+
+        packet.write_interleaved(&mut output)?;
+    }
+
+    output.write_trailer()?;
+
+    Ok(())
+}

--- a/examples/record_and_save.rs
+++ b/examples/record_and_save.rs
@@ -96,7 +96,7 @@ fn save_buffer(
 
     output.write_header()?;
 
-    for (_, frame) in video_buffer {
+    for frame in video_buffer.values() {
         let mut packet = ffmpeg_next::codec::packet::Packet::copy(&frame.data);
         packet.set_pts(Some(frame.pts));
         packet.set_dts(Some(frame.dts));

--- a/examples/record_and_save.rs
+++ b/examples/record_and_save.rs
@@ -98,7 +98,6 @@ fn save_buffer(
 
     for (_, frame) in video_buffer {
         let mut packet = ffmpeg_next::codec::packet::Packet::copy(&frame.data);
-        log::info!("Data: {:?}", frame.data);
         packet.set_pts(Some(frame.pts));
         packet.set_dts(Some(frame.dts));
 

--- a/examples/simple_record.rs
+++ b/examples/simple_record.rs
@@ -27,17 +27,15 @@ fn main() -> Result<(), WaycapError> {
     let stop = Arc::new(AtomicBool::new(false));
 
     let mut capture = CaptureBuilder::new()
-        .with_audio()
         .with_quality_preset(QualityPreset::Medium)
         .with_cursor_shown()
         .with_video_encoder(VideoEncoder::H264Nvenc)
-        .with_audio_encoder(AudioEncoder::Opus)
         .build()?;
 
     capture.start()?;
 
     let mut video_recv = capture.take_video_receiver();
-    let mut audio_recv = capture.take_audio_receiver().unwrap();
+    // let mut audio_recv = capture.take_audio_receiver().unwrap();
 
     let ctrlc_clone = Arc::clone(&stop);
     ctrlc::set_handler(move || {
@@ -63,28 +61,28 @@ fn main() -> Result<(), WaycapError> {
         std::thread::sleep(Duration::from_nanos(100));
     });
 
-    let h2stop = Arc::clone(&stop);
-    let handle2 = std::thread::spawn(move || loop {
-        if h2stop.load(std::sync::atomic::Ordering::Acquire) {
-            break;
-        }
-
-        while let Some(encoded_frame) = audio_recv.try_pop() {
-            log::info!("======= NEW AUDIO FRAME =======");
-            log::info!("PTS: {:?}", encoded_frame.pts);
-            log::info!("Capture Time Stamp: {:?}", encoded_frame.timestamp);
-            log::info!("===============================");
-        }
-
-        std::thread::sleep(Duration::from_nanos(100));
-    });
+    // let h2stop = Arc::clone(&stop);
+    // let handle2 = std::thread::spawn(move || loop {
+    //     if h2stop.load(std::sync::atomic::Ordering::Acquire) {
+    //         break;
+    //     }
+    //
+    //     while let Some(encoded_frame) = audio_recv.try_pop() {
+    //         log::info!("======= NEW AUDIO FRAME =======");
+    //         log::info!("PTS: {:?}", encoded_frame.pts);
+    //         log::info!("Capture Time Stamp: {:?}", encoded_frame.timestamp);
+    //         log::info!("===============================");
+    //     }
+    //
+    //     std::thread::sleep(Duration::from_nanos(100));
+    // });
 
     while !stop.load(std::sync::atomic::Ordering::Acquire) {
         std::thread::sleep(Duration::from_millis(100));
     }
 
     let _ = handle1.join();
-    let _ = handle2.join();
+    // let _ = handle2.join();
 
     Ok(())
 }

--- a/examples/simple_record.rs
+++ b/examples/simple_record.rs
@@ -27,6 +27,8 @@ fn main() -> Result<(), WaycapError> {
     let stop = Arc::new(AtomicBool::new(false));
 
     let mut capture = CaptureBuilder::new()
+        .with_audio()
+        .with_audio_encoder(AudioEncoder::Opus)
         .with_quality_preset(QualityPreset::Medium)
         .with_cursor_shown()
         .with_video_encoder(VideoEncoder::H264Nvenc)
@@ -35,7 +37,7 @@ fn main() -> Result<(), WaycapError> {
     capture.start()?;
 
     let mut video_recv = capture.take_video_receiver();
-    // let mut audio_recv = capture.take_audio_receiver().unwrap();
+    let mut audio_recv = capture.take_audio_receiver().unwrap();
 
     let ctrlc_clone = Arc::clone(&stop);
     ctrlc::set_handler(move || {
@@ -61,28 +63,28 @@ fn main() -> Result<(), WaycapError> {
         std::thread::sleep(Duration::from_nanos(100));
     });
 
-    // let h2stop = Arc::clone(&stop);
-    // let handle2 = std::thread::spawn(move || loop {
-    //     if h2stop.load(std::sync::atomic::Ordering::Acquire) {
-    //         break;
-    //     }
-    //
-    //     while let Some(encoded_frame) = audio_recv.try_pop() {
-    //         log::info!("======= NEW AUDIO FRAME =======");
-    //         log::info!("PTS: {:?}", encoded_frame.pts);
-    //         log::info!("Capture Time Stamp: {:?}", encoded_frame.timestamp);
-    //         log::info!("===============================");
-    //     }
-    //
-    //     std::thread::sleep(Duration::from_nanos(100));
-    // });
+    let h2stop = Arc::clone(&stop);
+    let handle2 = std::thread::spawn(move || loop {
+        if h2stop.load(std::sync::atomic::Ordering::Acquire) {
+            break;
+        }
+
+        while let Some(encoded_frame) = audio_recv.try_pop() {
+            // log::info!("======= NEW AUDIO FRAME =======");
+            // log::info!("PTS: {:?}", encoded_frame.pts);
+            // log::info!("Capture Time Stamp: {:?}", encoded_frame.timestamp);
+            // log::info!("===============================");
+        }
+
+        std::thread::sleep(Duration::from_nanos(100));
+    });
 
     while !stop.load(std::sync::atomic::Ordering::Acquire) {
         std::thread::sleep(Duration::from_millis(100));
     }
 
     let _ = handle1.join();
-    // let _ = handle2.join();
+    let _ = handle2.join();
 
     Ok(())
 }

--- a/examples/simple_record.rs
+++ b/examples/simple_record.rs
@@ -70,10 +70,10 @@ fn main() -> Result<(), WaycapError> {
         }
 
         while let Some(encoded_frame) = audio_recv.try_pop() {
-            // log::info!("======= NEW AUDIO FRAME =======");
-            // log::info!("PTS: {:?}", encoded_frame.pts);
-            // log::info!("Capture Time Stamp: {:?}", encoded_frame.timestamp);
-            // log::info!("===============================");
+            log::info!("======= NEW AUDIO FRAME =======");
+            log::info!("PTS: {:?}", encoded_frame.pts);
+            log::info!("Capture Time Stamp: {:?}", encoded_frame.timestamp);
+            log::info!("===============================");
         }
 
         std::thread::sleep(Duration::from_nanos(100));

--- a/src/capture/video.rs
+++ b/src/capture/video.rs
@@ -1,7 +1,7 @@
 use std::{
     os::fd::{FromRawFd, OwnedFd, RawFd},
     sync::{atomic::AtomicBool, mpsc, Arc},
-    time::{Duration, Instant},
+    time::Instant,
 };
 
 use pipewire::{

--- a/src/capture/video.rs
+++ b/src/capture/video.rs
@@ -1,7 +1,7 @@
 use std::{
     os::fd::{FromRawFd, OwnedFd, RawFd},
     sync::{atomic::AtomicBool, mpsc, Arc},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use pipewire::{

--- a/src/capture/video.rs
+++ b/src/capture/video.rs
@@ -10,7 +10,8 @@ use pipewire::{
     main_loop::MainLoop,
     spa::{
         buffer::{Data, DataType},
-        utils::Direction,
+        pod::{Property, PropertyFlags},
+        utils::{Choice, ChoiceEnum, ChoiceFlags, Direction},
     },
     stream::{Stream, StreamFlags, StreamState},
 };
@@ -23,10 +24,29 @@ use crate::types::video_frame::RawVideoFrame;
 
 use super::Terminate;
 
+// Literally stole these by looking at what OBS uses
+// just magic numbers to me no clue what these are
+// but they enable DMA Buf so it is what it is
+const NVIDIA_MODIFIERS: &[i64] = &[
+    216172782120099856,
+    216172782120099857,
+    216172782120099858,
+    216172782120099859,
+    216172782120099860,
+    216172782120099861,
+    216172782128496656,
+    216172782128496657,
+    216172782128496658,
+    216172782128496659,
+    216172782128496660,
+    216172782128496661,
+    72057594037927935,
+];
+
 pub struct VideoCapture {
     video_ready: Arc<AtomicBool>,
     audio_ready: Arc<AtomicBool>,
-    use_ram_copy: bool,
+    use_nvidia_modifiers: bool,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -38,12 +58,12 @@ impl VideoCapture {
     pub fn new(
         video_ready: Arc<AtomicBool>,
         audio_ready: Arc<AtomicBool>,
-        use_ram_copy: bool,
+        use_nvidia_modifiers: bool,
     ) -> Self {
         Self {
             video_ready,
             audio_ready,
-            use_ram_copy,
+            use_nvidia_modifiers,
         }
     }
 
@@ -150,7 +170,7 @@ impl VideoCapture {
                     user_data.video_format.framerate().denom
                 );
             })
-            .process(move |stream, _| {
+            .process(move |stream, udata| {
                 match stream.dequeue_buffer() {
                     None => log::debug!("out of buffers"),
                     Some(mut buffer) => {
@@ -182,23 +202,9 @@ impl VideoCapture {
                                     stride: data.chunk().stride(),
                                     offset: data.chunk().offset(),
                                     size: data.chunk().size(),
+                                    modifier: udata.video_format.modifier(),
                                 })
                                 .is_err()
-                        {
-                            log::error!(
-                                "Error sending video frame at: {:?}. Ring buf full?",
-                                time_us
-                            );
-                        } else if ringbuf_producer
-                            .try_push(RawVideoFrame {
-                                data: data.data().unwrap().to_vec(),
-                                timestamp: time_us,
-                                dmabuf_fd: None,
-                                stride: 0,
-                                offset: 0,
-                                size: 0,
-                            })
-                            .is_err()
                         {
                             log::error!(
                                 "Error sending video frame at: {:?}. Ring buf full?",
@@ -210,150 +216,145 @@ impl VideoCapture {
             })
             .register()?;
 
-        // TODO: Use features?
-        let ram_copy_spa_obj = pw::spa::pod::object!(
-            pw::spa::utils::SpaTypes::ObjectParamFormat,
-            pw::spa::param::ParamType::EnumFormat,
-            pw::spa::pod::property!(
-                pw::spa::param::format::FormatProperties::MediaType,
-                Id,
-                pw::spa::param::format::MediaType::Video
-            ),
-            pw::spa::pod::property!(
-                pw::spa::param::format::FormatProperties::MediaSubtype,
-                Id,
-                pw::spa::param::format::MediaSubtype::Raw
-            ),
-            pw::spa::pod::property!(
-                pw::spa::param::format::FormatProperties::VideoFormat,
-                Choice,
-                Enum,
-                Id,
-                pw::spa::param::video::VideoFormat::NV12,
-                pw::spa::param::video::VideoFormat::I420,
-                pw::spa::param::video::VideoFormat::BGRA,
-            ),
-            pw::spa::pod::property!(
-                pw::spa::param::format::FormatProperties::VideoSize,
-                Choice,
-                Range,
-                Rectangle,
-                pw::spa::utils::Rectangle {
-                    width: 2560,
-                    height: 1440
-                }, // Default
-                pw::spa::utils::Rectangle {
-                    width: 1,
-                    height: 1
-                }, // Min
-                pw::spa::utils::Rectangle {
-                    width: 4096,
-                    height: 4096
-                } // Max
-            ),
-            pw::spa::pod::property!(
-                pw::spa::param::format::FormatProperties::VideoFramerate,
-                Choice,
-                Range,
-                Fraction,
-                pw::spa::utils::Fraction { num: 240, denom: 1 }, // Default
-                pw::spa::utils::Fraction { num: 0, denom: 1 },   // Min
-                pw::spa::utils::Fraction { num: 244, denom: 1 }  // Max
-            ),
-        );
+        // TODO: Use features? Probably should not have runtime conditionals like this
+        let pw_obj = if self.use_nvidia_modifiers {
+            let nvidia_mod_property = Property {
+                key: pw::spa::param::format::FormatProperties::VideoModifier.as_raw(),
+                flags: PropertyFlags::empty(),
+                value: spa::pod::Value::Choice(spa::pod::ChoiceValue::Long(Choice::<i64>(
+                    ChoiceFlags::empty(),
+                    ChoiceEnum::<i64>::Enum {
+                        default: NVIDIA_MODIFIERS[0],
+                        alternatives: NVIDIA_MODIFIERS.to_vec(),
+                    },
+                ))),
+            };
 
-        let dma_buf_spa_obj = pw::spa::pod::object!(
-            pw::spa::utils::SpaTypes::ObjectParamFormat,
-            pw::spa::param::ParamType::EnumFormat,
-            pw::spa::pod::property!(
-                pw::spa::param::format::FormatProperties::MediaType,
-                Id,
-                pw::spa::param::format::MediaType::Video
-            ),
-            pw::spa::pod::property!(
-                pw::spa::param::format::FormatProperties::MediaSubtype,
-                Id,
-                pw::spa::param::format::MediaSubtype::Raw
-            ),
-            pw::spa::pod::property!(
-                pw::spa::param::format::FormatProperties::VideoModifier,
-                Long,
-                0
-            ),
-            pw::spa::pod::property!(
-                pw::spa::param::format::FormatProperties::VideoFormat,
-                Choice,
-                Enum,
-                Id,
-                pw::spa::param::video::VideoFormat::NV12,
-                pw::spa::param::video::VideoFormat::I420,
-                pw::spa::param::video::VideoFormat::BGRA,
-            ),
-            pw::spa::pod::property!(
-                pw::spa::param::format::FormatProperties::VideoSize,
-                Choice,
-                Range,
-                Rectangle,
-                pw::spa::utils::Rectangle {
-                    width: 2560,
-                    height: 1440
-                }, // Default
-                pw::spa::utils::Rectangle {
-                    width: 1,
-                    height: 1
-                }, // Min
-                pw::spa::utils::Rectangle {
-                    width: 4096,
-                    height: 4096
-                } // Max
-            ),
-            pw::spa::pod::property!(
-                pw::spa::param::format::FormatProperties::VideoFramerate,
-                Choice,
-                Range,
-                Fraction,
-                pw::spa::utils::Fraction { num: 240, denom: 1 }, // Default
-                pw::spa::utils::Fraction { num: 0, denom: 1 },   // Min
-                pw::spa::utils::Fraction { num: 244, denom: 1 }  // Max
-            ),
-        );
-
-        // TODO: Figure out how to make dma buf work with nvidia gpus
-        if self.use_ram_copy {
-            let video_spa_values: Vec<u8> = pw::spa::pod::serialize::PodSerializer::serialize(
-                std::io::Cursor::new(Vec::new()),
-                &pw::spa::pod::Value::Object(ram_copy_spa_obj),
-            )
-            .unwrap()
-            .0
-            .into_inner();
-            let mut video_params = [Pod::from_bytes(&video_spa_values).unwrap()];
-            video_stream.connect(
-                Direction::Input,
-                Some(stream_node),
-                StreamFlags::AUTOCONNECT | StreamFlags::MAP_BUFFERS,
-                &mut video_params,
-            )?;
-
-            log::debug!("Video Stream: {0:?}", video_stream);
+            Some(pw::spa::pod::object!(
+                pw::spa::utils::SpaTypes::ObjectParamFormat,
+                pw::spa::param::ParamType::EnumFormat,
+                pw::spa::pod::property!(
+                    pw::spa::param::format::FormatProperties::MediaType,
+                    Id,
+                    pw::spa::param::format::MediaType::Video
+                ),
+                pw::spa::pod::property!(
+                    pw::spa::param::format::FormatProperties::MediaSubtype,
+                    Id,
+                    pw::spa::param::format::MediaSubtype::Raw
+                ),
+                nvidia_mod_property,
+                pw::spa::pod::property!(
+                    pw::spa::param::format::FormatProperties::VideoFormat,
+                    Choice,
+                    Enum,
+                    Id,
+                    pw::spa::param::video::VideoFormat::NV12,
+                    pw::spa::param::video::VideoFormat::I420,
+                    pw::spa::param::video::VideoFormat::BGRA,
+                ),
+                pw::spa::pod::property!(
+                    pw::spa::param::format::FormatProperties::VideoSize,
+                    Choice,
+                    Range,
+                    Rectangle,
+                    pw::spa::utils::Rectangle {
+                        width: 2560,
+                        height: 1440
+                    }, // Default
+                    pw::spa::utils::Rectangle {
+                        width: 1,
+                        height: 1
+                    }, // Min
+                    pw::spa::utils::Rectangle {
+                        width: 4096,
+                        height: 4096
+                    } // Max
+                ),
+                pw::spa::pod::property!(
+                    pw::spa::param::format::FormatProperties::VideoFramerate,
+                    Choice,
+                    Range,
+                    Fraction,
+                    pw::spa::utils::Fraction { num: 240, denom: 1 }, // Default
+                    pw::spa::utils::Fraction { num: 0, denom: 1 },   // Min
+                    pw::spa::utils::Fraction { num: 244, denom: 1 }  // Max
+                ),
+            ))
         } else {
-            let video_spa_values: Vec<u8> = pw::spa::pod::serialize::PodSerializer::serialize(
-                std::io::Cursor::new(Vec::new()),
-                &pw::spa::pod::Value::Object(dma_buf_spa_obj),
-            )
-            .unwrap()
-            .0
-            .into_inner();
-            let mut video_params = [Pod::from_bytes(&video_spa_values).unwrap()];
-            video_stream.connect(
-                Direction::Input,
-                Some(stream_node),
-                StreamFlags::AUTOCONNECT | StreamFlags::MAP_BUFFERS,
-                &mut video_params,
-            )?;
+            Some(pw::spa::pod::object!(
+                pw::spa::utils::SpaTypes::ObjectParamFormat,
+                pw::spa::param::ParamType::EnumFormat,
+                pw::spa::pod::property!(
+                    pw::spa::param::format::FormatProperties::MediaType,
+                    Id,
+                    pw::spa::param::format::MediaType::Video
+                ),
+                pw::spa::pod::property!(
+                    pw::spa::param::format::FormatProperties::MediaSubtype,
+                    Id,
+                    pw::spa::param::format::MediaSubtype::Raw
+                ),
+                pw::spa::pod::property!(
+                    pw::spa::param::format::FormatProperties::VideoModifier,
+                    Long,
+                    0
+                ),
+                pw::spa::pod::property!(
+                    pw::spa::param::format::FormatProperties::VideoFormat,
+                    Choice,
+                    Enum,
+                    Id,
+                    pw::spa::param::video::VideoFormat::NV12,
+                    pw::spa::param::video::VideoFormat::I420,
+                    pw::spa::param::video::VideoFormat::BGRA,
+                ),
+                pw::spa::pod::property!(
+                    pw::spa::param::format::FormatProperties::VideoSize,
+                    Choice,
+                    Range,
+                    Rectangle,
+                    pw::spa::utils::Rectangle {
+                        width: 2560,
+                        height: 1440
+                    }, // Default
+                    pw::spa::utils::Rectangle {
+                        width: 1,
+                        height: 1
+                    }, // Min
+                    pw::spa::utils::Rectangle {
+                        width: 4096,
+                        height: 4096
+                    } // Max
+                ),
+                pw::spa::pod::property!(
+                    pw::spa::param::format::FormatProperties::VideoFramerate,
+                    Choice,
+                    Range,
+                    Fraction,
+                    pw::spa::utils::Fraction { num: 240, denom: 1 }, // Default
+                    pw::spa::utils::Fraction { num: 0, denom: 1 },   // Min
+                    pw::spa::utils::Fraction { num: 244, denom: 1 }  // Max
+                ),
+            ))
+        };
 
-            log::debug!("Video Stream: {0:?}", video_stream);
-        }
+        let video_spa_values: Vec<u8> = pw::spa::pod::serialize::PodSerializer::serialize(
+            std::io::Cursor::new(Vec::new()),
+            &pw::spa::pod::Value::Object(pw_obj.unwrap()),
+        )
+        .unwrap()
+        .0
+        .into_inner();
+        let mut video_params = [Pod::from_bytes(&video_spa_values).unwrap()];
+        video_stream.connect(
+            Direction::Input,
+            Some(stream_node),
+            StreamFlags::AUTOCONNECT | StreamFlags::MAP_BUFFERS,
+            &mut video_params,
+        )?;
+
+        log::debug!("Video Stream: {0:?}", video_stream);
 
         pw_loop.run();
         Ok(())

--- a/src/encoders/cuda.rs
+++ b/src/encoders/cuda.rs
@@ -1,180 +1,21 @@
 use std::ffi::c_void;
-use std::os::raw::{c_int, c_uint};
 
-// Type definitions
-pub type CUcontext = *mut c_void;
-pub type CUstream = *mut c_void;
-pub type CUgraphicsResource = *mut c_void;
-pub type CUarray = *mut c_void;
-pub type CUresult = u32;
-pub type CUdeviceptr = u64;
-pub type CUdevice = c_int;
+use cust::sys::{CUcontext, CUgraphicsResource, CUresult, CUstream};
+use gl::types::{GLenum, GLuint};
+use libc::c_uint;
 
-// Constants for context creation
-pub const CU_CTX_SCHED_AUTO: u32 = 0x00;
-pub const CU_CTX_SCHED_SPIN: u32 = 0x01;
-pub const CU_CTX_SCHED_YIELD: u32 = 0x02;
-pub const CU_CTX_SCHED_BLOCKING_SYNC: u32 = 0x04;
-
-// Graphics resource flags
-pub const CU_GRAPHICS_MAP_RESOURCE_FLAGS_NONE: u32 = 0x00;
-pub const CU_GRAPHICS_REGISTER_FLAGS_NONE: u32 = 0x00;
-pub const CU_GRAPHICS_REGISTER_FLAGS_READ_NONE: u32 = 0x00;
-pub const CU_GRAPHICS_REGISTER_FLAGS_WRITE_DISCARD: u32 = 0x01;
-pub const CU_GRAPHICS_REGISTER_FLAGS_SURFACE_LDST: u32 = 0x02;
-pub const CU_GRAPHICS_REGISTER_FLAGS_TEXTURE_GATHER: u32 = 0x04;
-
-// Memory type enumeration
-#[repr(C)]
-pub enum CUmemorytype {
-    CU_MEMORYTYPE_HOST = 0x01,
-    CU_MEMORYTYPE_DEVICE = 0x02,
-    CU_MEMORYTYPE_ARRAY = 0x03,
-    CU_MEMORYTYPE_UNIFIED = 0x04,
-}
-
-// CUDA 2D memory copy structure
-#[repr(C)]
-pub struct CUDA_MEMCPY2D {
-    pub srcXInBytes: usize,
-    pub srcY: usize,
-    pub srcMemoryType: u32,
-    pub srcHost: *const c_void,
-    pub srcDevice: CUdeviceptr,
-    pub srcArray: CUarray,
-    pub srcPitch: usize,
-    pub dstXInBytes: usize,
-    pub dstY: usize,
-    pub dstMemoryType: u32,
-    pub dstHost: *mut c_void,
-    pub dstDevice: CUdeviceptr,
-    pub dstArray: CUarray,
-    pub dstPitch: usize,
-    pub WidthInBytes: usize,
-    pub Height: usize,
-}
-
-// Array format enumeration
-#[repr(C)]
-pub enum CUarray_format {
-    CU_AD_FORMAT_UNSIGNED_INT8 = 0x01,
-    CU_AD_FORMAT_UNSIGNED_INT16 = 0x02,
-    CU_AD_FORMAT_UNSIGNED_INT32 = 0x03,
-    CU_AD_FORMAT_SIGNED_INT8 = 0x08,
-    CU_AD_FORMAT_SIGNED_INT16 = 0x09,
-    CU_AD_FORMAT_SIGNED_INT32 = 0x0a,
-    CU_AD_FORMAT_HALF = 0x10,
-    CU_AD_FORMAT_FLOAT = 0x20,
-}
-
-// CUDA array descriptor structure
-#[repr(C)]
-pub struct CUDA_ARRAY_DESCRIPTOR {
-    pub Format: CUarray_format,
-    pub Height: usize,
-    pub Width: usize,
-    pub NumChannels: u32,
-}
-
-// FFmpeg CUDA device context structure
 #[repr(C)]
 pub struct AVCUDADeviceContext {
     pub cuda_ctx: CUcontext,
     pub stream: CUstream,
-    pub internal: *mut std::ffi::c_void, // AVCUDADeviceContextInternal*
+    pub internarl: *mut c_void,
 }
 
-// External function declarations
-extern "C" {
-    // CUDA Driver API initialization
-    /// Initialize CUDA driver API
-    pub fn cuInit(flags: c_uint) -> CUresult;
-
-    // Device management
-    /// Get number of CUDA devices
-    pub fn cuDeviceGetCount(count: *mut c_int) -> CUresult;
-
-    /// Get CUDA device handle
-    pub fn cuDeviceGet(device: *mut CUdevice, ordinal: c_int) -> CUresult;
-
-    /// Get device properties
-    pub fn cuDeviceGetName(name: *mut u8, len: c_int, dev: CUdevice) -> CUresult;
-
-    /// Get device attribute
-    pub fn cuDeviceGetAttribute(pi: *mut c_int, attrib: c_uint, dev: CUdevice) -> CUresult;
-
-    // Context management
-    /// Create CUDA context with OpenGL interop (modern way)
-    pub fn cuGLCtxCreate_v2(pCtx: *mut CUcontext, flags: c_uint, device: CUdevice) -> CUresult;
-
-    /// Create regular CUDA context
-    pub fn cuCtxCreate_v2(pCtx: *mut CUcontext, flags: c_uint, device: CUdevice) -> CUresult;
-
-    /// Destroy CUDA context
-    pub fn cuCtxDestroy_v2(ctx: CUcontext) -> CUresult;
-
-    /// Set current CUDA context
-    pub fn cuCtxSetCurrent(ctx: CUcontext) -> CUresult;
-
-    /// Get current CUDA context
-    pub fn cuCtxGetCurrent(pCtx: *mut CUcontext) -> CUresult;
-
-    /// Push context onto current thread's context stack
-    pub fn cuCtxPushCurrent_v2(ctx: CUcontext) -> CUresult;
-
-    /// Pop context from current thread's context stack
-    pub fn cuCtxPopCurrent_v2(pCtx: *mut CUcontext) -> CUresult;
-
-    /// Get device associated with current context
-    pub fn cuCtxGetDevice(device: *mut CUdevice) -> CUresult;
-
-    /// Synchronize context
-    pub fn cuCtxSynchronize() -> CUresult;
-
-    // OpenGL interop functions
-    /// Register OpenGL image with CUDA
+unsafe extern "C" {
     pub fn cuGraphicsGLRegisterImage(
         resource: *mut CUgraphicsResource,
-        image: u32,
-        target: u32,
-        flags: u32,
-    ) -> CUresult;
-
-    /// Set map flags for graphics resource
-    pub fn cuGraphicsResourceSetMapFlags(resource: CUgraphicsResource, flags: u32) -> CUresult;
-
-    /// Map graphics resources for CUDA access
-    pub fn cuGraphicsMapResources(
-        count: c_uint,
-        resources: *const CUgraphicsResource,
-        stream: CUstream,
-    ) -> CUresult;
-
-    /// Unmap graphics resources
-    pub fn cuGraphicsUnmapResources(
-        count: c_uint,
-        resources: *const CUgraphicsResource,
-        stream: CUstream,
-    ) -> CUresult;
-
-    /// Get mapped array from graphics resource
-    pub fn cuGraphicsSubResourceGetMappedArray(
-        array: *mut CUarray,
-        resource: CUgraphicsResource,
-        array_index: u32,
-        mip_level: u32,
-    ) -> CUresult;
-
-    /// Unregister graphics resource
-    pub fn cuGraphicsUnregisterResource(resource: CUgraphicsResource) -> CUresult;
-
-    // Memory operations
-    /// 2D memory copy
-    pub fn cuMemcpy2D(pCopy: *const CUDA_MEMCPY2D) -> CUresult;
-
-    /// Get array descriptor
-    pub fn cuArrayGetDescriptor(
-        pArrayDescriptor: *mut CUDA_ARRAY_DESCRIPTOR,
-        hArray: CUarray,
+        image: GLuint,
+        target: GLenum,
+        flags: c_uint,
     ) -> CUresult;
 }

--- a/src/encoders/cuda.rs
+++ b/src/encoders/cuda.rs
@@ -1,14 +1,30 @@
 use std::ffi::c_void;
-use std::os::raw::c_uint;
+use std::os::raw::{c_int, c_uint};
 
+// Type definitions
 pub type CUcontext = *mut c_void;
 pub type CUstream = *mut c_void;
 pub type CUgraphicsResource = *mut c_void;
 pub type CUarray = *mut c_void;
 pub type CUresult = u32;
 pub type CUdeviceptr = u64;
-pub const CU_GRAPHICS_MAP_RESOURCE_FLAGS_NONE: u32 = 0x00;
+pub type CUdevice = c_int;
 
+// Constants for context creation
+pub const CU_CTX_SCHED_AUTO: u32 = 0x00;
+pub const CU_CTX_SCHED_SPIN: u32 = 0x01;
+pub const CU_CTX_SCHED_YIELD: u32 = 0x02;
+pub const CU_CTX_SCHED_BLOCKING_SYNC: u32 = 0x04;
+
+// Graphics resource flags
+pub const CU_GRAPHICS_MAP_RESOURCE_FLAGS_NONE: u32 = 0x00;
+pub const CU_GRAPHICS_REGISTER_FLAGS_NONE: u32 = 0x00;
+pub const CU_GRAPHICS_REGISTER_FLAGS_READ_NONE: u32 = 0x00;
+pub const CU_GRAPHICS_REGISTER_FLAGS_WRITE_DISCARD: u32 = 0x01;
+pub const CU_GRAPHICS_REGISTER_FLAGS_SURFACE_LDST: u32 = 0x02;
+pub const CU_GRAPHICS_REGISTER_FLAGS_TEXTURE_GATHER: u32 = 0x04;
+
+// Memory type enumeration
 #[repr(C)]
 pub enum CUmemorytype {
     CU_MEMORYTYPE_HOST = 0x01,
@@ -17,28 +33,28 @@ pub enum CUmemorytype {
     CU_MEMORYTYPE_UNIFIED = 0x04,
 }
 
+// CUDA 2D memory copy structure
 #[repr(C)]
 pub struct CUDA_MEMCPY2D {
-    pub srcXInBytes: usize, // size_t
-    pub srcY: usize,        // size_t
-    pub srcMemoryType: u32, // CUmemorytype
+    pub srcXInBytes: usize,
+    pub srcY: usize,
+    pub srcMemoryType: u32,
     pub srcHost: *const c_void,
-    pub srcDevice: CUdeviceptr, // u64
-    pub srcArray: CUarray,      // *mut c_void
-    pub srcPitch: usize,        // size_t
-
-    pub dstXInBytes: usize, // size_t
-    pub dstY: usize,        // size_t
-    pub dstMemoryType: u32, // CUmemorytype
+    pub srcDevice: CUdeviceptr,
+    pub srcArray: CUarray,
+    pub srcPitch: usize,
+    pub dstXInBytes: usize,
+    pub dstY: usize,
+    pub dstMemoryType: u32,
     pub dstHost: *mut c_void,
-    pub dstDevice: CUdeviceptr, // u64
-    pub dstArray: CUarray,      // *mut c_void
-    pub dstPitch: usize,        // size_t
-
-    pub WidthInBytes: usize, // size_t
-    pub Height: usize,       // size_t
+    pub dstDevice: CUdeviceptr,
+    pub dstArray: CUarray,
+    pub dstPitch: usize,
+    pub WidthInBytes: usize,
+    pub Height: usize,
 }
 
+// Array format enumeration
 #[repr(C)]
 pub enum CUarray_format {
     CU_AD_FORMAT_UNSIGNED_INT8 = 0x01,
@@ -51,6 +67,7 @@ pub enum CUarray_format {
     CU_AD_FORMAT_FLOAT = 0x20,
 }
 
+// CUDA array descriptor structure
 #[repr(C)]
 pub struct CUDA_ARRAY_DESCRIPTOR {
     pub Format: CUarray_format,
@@ -59,9 +76,63 @@ pub struct CUDA_ARRAY_DESCRIPTOR {
     pub NumChannels: u32,
 }
 
+// FFmpeg CUDA device context structure
+#[repr(C)]
+pub struct AVCUDADeviceContext {
+    pub cuda_ctx: CUcontext,
+    pub stream: CUstream,
+    pub internal: *mut std::ffi::c_void, // AVCUDADeviceContextInternal*
+}
+
+// External function declarations
 extern "C" {
+    // CUDA Driver API initialization
+    /// Initialize CUDA driver API
+    pub fn cuInit(flags: c_uint) -> CUresult;
+
+    // Device management
+    /// Get number of CUDA devices
+    pub fn cuDeviceGetCount(count: *mut c_int) -> CUresult;
+
+    /// Get CUDA device handle
+    pub fn cuDeviceGet(device: *mut CUdevice, ordinal: c_int) -> CUresult;
+
+    /// Get device properties
+    pub fn cuDeviceGetName(name: *mut u8, len: c_int, dev: CUdevice) -> CUresult;
+
+    /// Get device attribute
+    pub fn cuDeviceGetAttribute(pi: *mut c_int, attrib: c_uint, dev: CUdevice) -> CUresult;
+
+    // Context management
+    /// Create CUDA context with OpenGL interop (modern way)
+    pub fn cuGLCtxCreate_v2(pCtx: *mut CUcontext, flags: c_uint, device: CUdevice) -> CUresult;
+
+    /// Create regular CUDA context
+    pub fn cuCtxCreate_v2(pCtx: *mut CUcontext, flags: c_uint, device: CUdevice) -> CUresult;
+
+    /// Destroy CUDA context
+    pub fn cuCtxDestroy_v2(ctx: CUcontext) -> CUresult;
+
+    /// Set current CUDA context
     pub fn cuCtxSetCurrent(ctx: CUcontext) -> CUresult;
 
+    /// Get current CUDA context
+    pub fn cuCtxGetCurrent(pCtx: *mut CUcontext) -> CUresult;
+
+    /// Push context onto current thread's context stack
+    pub fn cuCtxPushCurrent_v2(ctx: CUcontext) -> CUresult;
+
+    /// Pop context from current thread's context stack
+    pub fn cuCtxPopCurrent_v2(pCtx: *mut CUcontext) -> CUresult;
+
+    /// Get device associated with current context
+    pub fn cuCtxGetDevice(device: *mut CUdevice) -> CUresult;
+
+    /// Synchronize context
+    pub fn cuCtxSynchronize() -> CUresult;
+
+    // OpenGL interop functions
+    /// Register OpenGL image with CUDA
     pub fn cuGraphicsGLRegisterImage(
         resource: *mut CUgraphicsResource,
         image: u32,
@@ -69,12 +140,24 @@ extern "C" {
         flags: u32,
     ) -> CUresult;
 
+    /// Set map flags for graphics resource
+    pub fn cuGraphicsResourceSetMapFlags(resource: CUgraphicsResource, flags: u32) -> CUresult;
+
+    /// Map graphics resources for CUDA access
     pub fn cuGraphicsMapResources(
         count: c_uint,
         resources: *const CUgraphicsResource,
         stream: CUstream,
     ) -> CUresult;
 
+    /// Unmap graphics resources
+    pub fn cuGraphicsUnmapResources(
+        count: c_uint,
+        resources: *const CUgraphicsResource,
+        stream: CUstream,
+    ) -> CUresult;
+
+    /// Get mapped array from graphics resource
     pub fn cuGraphicsSubResourceGetMappedArray(
         array: *mut CUarray,
         resource: CUgraphicsResource,
@@ -82,29 +165,16 @@ extern "C" {
         mip_level: u32,
     ) -> CUresult;
 
-    pub fn cuGraphicsUnmapResources(
-        count: c_uint,
-        resources: *const CUgraphicsResource,
-        stream: CUstream,
-    ) -> CUresult;
-
+    /// Unregister graphics resource
     pub fn cuGraphicsUnregisterResource(resource: CUgraphicsResource) -> CUresult;
 
+    // Memory operations
+    /// 2D memory copy
     pub fn cuMemcpy2D(pCopy: *const CUDA_MEMCPY2D) -> CUresult;
 
-    pub fn cuCtxGetCurrent(pCtx: *const CUcontext) -> CUresult;
-
+    /// Get array descriptor
     pub fn cuArrayGetDescriptor(
         pArrayDescriptor: *mut CUDA_ARRAY_DESCRIPTOR,
-        hArray: *mut c_void,
+        hArray: CUarray,
     ) -> CUresult;
-
-    pub fn cuGraphicsResourceSetMapFlags(resource: CUgraphicsResource, flags: u32) -> CUresult;
-}
-
-#[repr(C)]
-pub struct AVCUDADeviceContext {
-    pub cuda_ctx: CUcontext,
-    pub stream: CUstream,
-    pub internal: *mut std::ffi::c_void, // AVCUDADeviceContextInternal*
 }

--- a/src/encoders/cuda.rs
+++ b/src/encoders/cuda.rs
@@ -1,0 +1,74 @@
+use std::ffi::c_void;
+use std::os::raw::c_uint;
+
+pub type CUcontext = *mut c_void;
+pub type CUstream = *mut c_void;
+pub type CUgraphicsResource = *mut c_void;
+pub type CUarray = *mut c_void;
+
+#[repr(C)]
+pub struct CUDA_MEMCPY2D {
+    pub srcXInBytes: usize,
+    pub srcY: usize,
+    pub srcMemoryType: i32,
+    pub srcHost: *const c_void,
+    pub srcDevice: *const c_void,
+    pub srcArray: CUarray,
+    pub srcPitch: usize,
+
+    pub dstXInBytes: usize,
+    pub dstY: usize,
+    pub dstMemoryType: i32,
+    pub dstHost: *mut c_void,
+    pub dstDevice: *mut c_void,
+    pub dstArray: CUarray,
+    pub dstPitch: usize,
+
+    pub WidthInBytes: usize,
+    pub Height: usize,
+}
+
+extern "C" {
+    pub fn cuCtxSetCurrent(ctx: CUcontext) -> i32;
+
+    pub fn cuGraphicsGLRegisterImage(
+        resource: *mut CUgraphicsResource,
+        image: u32,
+        target: u32,
+        flags: u32,
+    ) -> i32;
+
+    pub fn cuGraphicsMapResources(
+        count: c_uint,
+        resources: *const CUgraphicsResource,
+        stream: CUstream,
+    ) -> i32;
+
+    pub fn cuGraphicsSubResourceGetMappedArray(
+        array: *mut CUarray,
+        resource: CUgraphicsResource,
+        array_index: u32,
+        mip_level: u32,
+    ) -> i32;
+
+    pub fn cuGraphicsUnmapResources(
+        count: c_uint,
+        resources: *const CUgraphicsResource,
+        stream: CUstream,
+    ) -> i32;
+
+    pub fn cuGraphicsUnregisterResource(resource: CUgraphicsResource) -> i32;
+
+    pub fn cuMemcpy2D(pCopy: *const CUDA_MEMCPY2D) -> i32;
+
+    // TODO: Figure out how to get egl and cuda to share the context
+    // Looks like I need to interop with GL to get dma buffer support for nvenc :(
+    pub fn cuGLCtxCreate(pCtx: *const CUcontext, flags: u32, device: i32) -> i32;
+}
+
+#[repr(C)]
+pub struct AVCUDADeviceContext {
+    pub cuda_ctx: CUcontext,
+    pub stream: CUstream,
+    pub internal: *mut std::ffi::c_void, // AVCUDADeviceContextInternal*
+}

--- a/src/encoders/cuda.rs
+++ b/src/encoders/cuda.rs
@@ -5,65 +5,101 @@ pub type CUcontext = *mut c_void;
 pub type CUstream = *mut c_void;
 pub type CUgraphicsResource = *mut c_void;
 pub type CUarray = *mut c_void;
+pub type CUresult = u32;
+pub type CUdeviceptr = u64;
+pub const CU_GRAPHICS_MAP_RESOURCE_FLAGS_NONE: u32 = 0x00;
+
+#[repr(C)]
+pub enum CUmemorytype {
+    CU_MEMORYTYPE_HOST = 0x01,
+    CU_MEMORYTYPE_DEVICE = 0x02,
+    CU_MEMORYTYPE_ARRAY = 0x03,
+    CU_MEMORYTYPE_UNIFIED = 0x04,
+}
 
 #[repr(C)]
 pub struct CUDA_MEMCPY2D {
-    pub srcXInBytes: usize,
-    pub srcY: usize,
-    pub srcMemoryType: i32,
+    pub srcXInBytes: usize, // size_t
+    pub srcY: usize,        // size_t
+    pub srcMemoryType: u32, // CUmemorytype
     pub srcHost: *const c_void,
-    pub srcDevice: *const c_void,
-    pub srcArray: CUarray,
-    pub srcPitch: usize,
+    pub srcDevice: CUdeviceptr, // u64
+    pub srcArray: CUarray,      // *mut c_void
+    pub srcPitch: usize,        // size_t
 
-    pub dstXInBytes: usize,
-    pub dstY: usize,
-    pub dstMemoryType: i32,
+    pub dstXInBytes: usize, // size_t
+    pub dstY: usize,        // size_t
+    pub dstMemoryType: u32, // CUmemorytype
     pub dstHost: *mut c_void,
-    pub dstDevice: *mut c_void,
-    pub dstArray: CUarray,
-    pub dstPitch: usize,
+    pub dstDevice: CUdeviceptr, // u64
+    pub dstArray: CUarray,      // *mut c_void
+    pub dstPitch: usize,        // size_t
 
-    pub WidthInBytes: usize,
+    pub WidthInBytes: usize, // size_t
+    pub Height: usize,       // size_t
+}
+
+#[repr(C)]
+pub enum CUarray_format {
+    CU_AD_FORMAT_UNSIGNED_INT8 = 0x01,
+    CU_AD_FORMAT_UNSIGNED_INT16 = 0x02,
+    CU_AD_FORMAT_UNSIGNED_INT32 = 0x03,
+    CU_AD_FORMAT_SIGNED_INT8 = 0x08,
+    CU_AD_FORMAT_SIGNED_INT16 = 0x09,
+    CU_AD_FORMAT_SIGNED_INT32 = 0x0a,
+    CU_AD_FORMAT_HALF = 0x10,
+    CU_AD_FORMAT_FLOAT = 0x20,
+}
+
+#[repr(C)]
+pub struct CUDA_ARRAY_DESCRIPTOR {
+    pub Format: CUarray_format,
     pub Height: usize,
+    pub Width: usize,
+    pub NumChannels: u32,
 }
 
 extern "C" {
-    pub fn cuCtxSetCurrent(ctx: CUcontext) -> i32;
+    pub fn cuCtxSetCurrent(ctx: CUcontext) -> CUresult;
 
     pub fn cuGraphicsGLRegisterImage(
         resource: *mut CUgraphicsResource,
         image: u32,
         target: u32,
         flags: u32,
-    ) -> i32;
+    ) -> CUresult;
 
     pub fn cuGraphicsMapResources(
         count: c_uint,
         resources: *const CUgraphicsResource,
         stream: CUstream,
-    ) -> i32;
+    ) -> CUresult;
 
     pub fn cuGraphicsSubResourceGetMappedArray(
         array: *mut CUarray,
         resource: CUgraphicsResource,
         array_index: u32,
         mip_level: u32,
-    ) -> i32;
+    ) -> CUresult;
 
     pub fn cuGraphicsUnmapResources(
         count: c_uint,
         resources: *const CUgraphicsResource,
         stream: CUstream,
-    ) -> i32;
+    ) -> CUresult;
 
-    pub fn cuGraphicsUnregisterResource(resource: CUgraphicsResource) -> i32;
+    pub fn cuGraphicsUnregisterResource(resource: CUgraphicsResource) -> CUresult;
 
-    pub fn cuMemcpy2D(pCopy: *const CUDA_MEMCPY2D) -> i32;
+    pub fn cuMemcpy2D(pCopy: *const CUDA_MEMCPY2D) -> CUresult;
 
-    // TODO: Figure out how to get egl and cuda to share the context
-    // Looks like I need to interop with GL to get dma buffer support for nvenc :(
-    pub fn cuGLCtxCreate(pCtx: *const CUcontext, flags: u32, device: i32) -> i32;
+    pub fn cuCtxGetCurrent(pCtx: *const CUcontext) -> CUresult;
+
+    pub fn cuArrayGetDescriptor(
+        pArrayDescriptor: *mut CUDA_ARRAY_DESCRIPTOR,
+        hArray: *mut c_void,
+    ) -> CUresult;
+
+    pub fn cuGraphicsResourceSetMapFlags(resource: CUgraphicsResource, flags: u32) -> CUresult;
 }
 
 #[repr(C)]

--- a/src/encoders/mod.rs
+++ b/src/encoders/mod.rs
@@ -3,3 +3,4 @@ pub mod opus_encoder;
 pub mod video;
 pub mod vaapi_encoder;
 pub mod nvenc_encoder;
+mod cuda;

--- a/src/encoders/vaapi_encoder.rs
+++ b/src/encoders/vaapi_encoder.rs
@@ -60,7 +60,7 @@ impl VideoEncoder for VaapiEncoder {
         })
     }
 
-    fn process_egl_texture(&mut self, id: u32, capture_timestamp: i64) -> Result<()> {
+    fn process_egl_texture(&mut self, capture_timestamp: i64) -> Result<()> {
         log::error!("Not implemented for vaapi");
         Ok(())
     }

--- a/src/encoders/vaapi_encoder.rs
+++ b/src/encoders/vaapi_encoder.rs
@@ -1,7 +1,4 @@
-use std::{
-    any::Any,
-    ptr::{null, null_mut},
-};
+use std::{any::Any, ptr::null_mut};
 
 use drm_fourcc::DrmFourcc;
 use ffmpeg_next::{
@@ -60,16 +57,7 @@ impl VideoEncoder for VaapiEncoder {
         })
     }
 
-    fn process_egl_texture(&mut self, capture_timestamp: i64) -> Result<()> {
-        log::error!("Not implemented for vaapi");
-        Ok(())
-    }
-
     fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
 

--- a/src/encoders/vaapi_encoder.rs
+++ b/src/encoders/vaapi_encoder.rs
@@ -1,4 +1,4 @@
-use std::ptr::null_mut;
+use std::ptr::{null, null_mut};
 
 use drm_fourcc::DrmFourcc;
 use ffmpeg_next::{
@@ -55,6 +55,18 @@ impl VideoEncoder for VaapiEncoder {
             encoded_frame_sender: Some(video_ring_sender),
             filter_graph,
         })
+    }
+
+    fn process_egl_texture(&mut self, id: u32, capture_timestamp: i64) -> Result<()> {
+        log::error!("Not implemented for vaapi");
+        Ok(())
+    }
+
+    fn enable_gl_interop_on_existing_context(
+        &mut self,
+        egl_ctx: &crate::waycap_egl::EglContext,
+    ) -> Result<()> {
+        Ok(())
     }
 
     fn process(&mut self, frame: &RawVideoFrame) -> Result<()> {

--- a/src/encoders/vaapi_encoder.rs
+++ b/src/encoders/vaapi_encoder.rs
@@ -1,4 +1,7 @@
-use std::ptr::{null, null_mut};
+use std::{
+    any::Any,
+    ptr::{null, null_mut},
+};
 
 use drm_fourcc::DrmFourcc;
 use ffmpeg_next::{
@@ -57,13 +60,17 @@ impl VideoEncoder for VaapiEncoder {
         })
     }
 
-    fn process_egl_texture(
-        &mut self,
-        id: u32,
-        capture_timestamp: i64,
-    ) -> Result<()> {
+    fn process_egl_texture(&mut self, id: u32, capture_timestamp: i64) -> Result<()> {
         log::error!("Not implemented for vaapi");
         Ok(())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
     }
 
     fn process(&mut self, frame: &RawVideoFrame) -> Result<()> {

--- a/src/encoders/vaapi_encoder.rs
+++ b/src/encoders/vaapi_encoder.rs
@@ -57,15 +57,12 @@ impl VideoEncoder for VaapiEncoder {
         })
     }
 
-    fn process_egl_texture(&mut self, id: u32, capture_timestamp: i64) -> Result<()> {
-        log::error!("Not implemented for vaapi");
-        Ok(())
-    }
-
-    fn enable_gl_interop_on_existing_context(
+    fn process_egl_texture(
         &mut self,
-        egl_ctx: &crate::waycap_egl::EglContext,
+        id: u32,
+        capture_timestamp: i64,
     ) -> Result<()> {
+        log::error!("Not implemented for vaapi");
         Ok(())
     }
 

--- a/src/encoders/video.rs
+++ b/src/encoders/video.rs
@@ -1,10 +1,10 @@
+use std::any::Any;
 use std::ffi::CString;
 use std::ptr::null_mut;
 
 use crate::types::error::{Result, WaycapError};
 use crate::types::video_frame::RawVideoFrame;
 use crate::types::{config::QualityPreset, video_frame::EncodedVideoFrame};
-use crate::waycap_egl::EglContext;
 use ffmpeg_next::ffi::{av_hwdevice_ctx_create, av_hwframe_ctx_alloc, AVBufferRef};
 use ffmpeg_next::{self as ffmpeg, Dictionary};
 use ringbuf::HeapCons;
@@ -21,11 +21,10 @@ pub trait VideoEncoder: Send {
     fn drop_encoder(&mut self);
     fn get_encoder(&self) -> &Option<ffmpeg::codec::encoder::Video>;
     fn take_encoded_recv(&mut self) -> Option<HeapCons<EncodedVideoFrame>>;
-    fn process_egl_texture(
-        &mut self,
-        id: u32,
-        capture_time: i64,
-    ) -> Result<()>;
+    fn process_egl_texture(&mut self, id: u32, capture_time: i64) -> Result<()>;
+
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
 }
 
 pub fn create_hw_frame_ctx(device: *mut AVBufferRef) -> Result<*mut AVBufferRef> {

--- a/src/encoders/video.rs
+++ b/src/encoders/video.rs
@@ -21,7 +21,7 @@ pub trait VideoEncoder: Send {
     fn drop_encoder(&mut self);
     fn get_encoder(&self) -> &Option<ffmpeg::codec::encoder::Video>;
     fn take_encoded_recv(&mut self) -> Option<HeapCons<EncodedVideoFrame>>;
-    fn process_egl_texture(&mut self, id: u32, capture_time: i64) -> Result<()>;
+    fn process_egl_texture(&mut self, capture_time: i64) -> Result<()>;
 
     fn as_any(&self) -> &dyn Any;
     fn as_any_mut(&mut self) -> &mut dyn Any;

--- a/src/encoders/video.rs
+++ b/src/encoders/video.rs
@@ -4,6 +4,7 @@ use std::ptr::null_mut;
 use crate::types::error::{Result, WaycapError};
 use crate::types::video_frame::RawVideoFrame;
 use crate::types::{config::QualityPreset, video_frame::EncodedVideoFrame};
+use crate::waycap_egl::EglContext;
 use ffmpeg_next::ffi::{av_hwdevice_ctx_create, av_hwframe_ctx_alloc, AVBufferRef};
 use ffmpeg_next::{self as ffmpeg};
 use ringbuf::HeapCons;
@@ -20,6 +21,8 @@ pub trait VideoEncoder: Send {
     fn drop_encoder(&mut self);
     fn get_encoder(&self) -> &Option<ffmpeg::codec::encoder::Video>;
     fn take_encoded_recv(&mut self) -> Option<HeapCons<EncodedVideoFrame>>;
+    fn process_egl_texture(&mut self, id: u32, capture_time: i64) -> Result<()>;
+    fn enable_gl_interop_on_existing_context(&mut self, egl_ctx: &EglContext) -> Result<()>;
 }
 
 pub fn create_hw_frame_ctx(device: *mut AVBufferRef) -> Result<*mut AVBufferRef> {

--- a/src/encoders/video.rs
+++ b/src/encoders/video.rs
@@ -5,8 +5,8 @@ use std::ptr::null_mut;
 use crate::types::error::{Result, WaycapError};
 use crate::types::video_frame::RawVideoFrame;
 use crate::types::{config::QualityPreset, video_frame::EncodedVideoFrame};
-use ffmpeg_next::ffi::{av_hwdevice_ctx_create, av_hwframe_ctx_alloc, AVBufferRef};
-use ffmpeg_next::{self as ffmpeg, Dictionary};
+use ffmpeg_next::{self as ffmpeg};
+use ffmpeg::ffi::{av_hwdevice_ctx_create, av_hwframe_ctx_alloc, AVBufferRef};
 use ringbuf::HeapCons;
 
 pub const GOP_SIZE: u32 = 30;
@@ -21,10 +21,8 @@ pub trait VideoEncoder: Send {
     fn drop_encoder(&mut self);
     fn get_encoder(&self) -> &Option<ffmpeg::codec::encoder::Video>;
     fn take_encoded_recv(&mut self) -> Option<HeapCons<EncodedVideoFrame>>;
-    fn process_egl_texture(&mut self, capture_time: i64) -> Result<()>;
 
     fn as_any(&self) -> &dyn Any;
-    fn as_any_mut(&mut self) -> &mut dyn Any;
 }
 
 pub fn create_hw_frame_ctx(device: *mut AVBufferRef) -> Result<*mut AVBufferRef> {
@@ -52,25 +50,6 @@ pub fn create_hw_device(device_type: ffmpeg_next::ffi::AVHWDeviceType) -> Result
             null_mut(),
             0,
         );
-        if ret < 0 {
-            return Err(WaycapError::Init(format!(
-                "Failed to create hardware device: Error code {}",
-                ret
-            )));
-        }
-
-        Ok(device)
-    }
-}
-
-pub fn create_hw_device_with_opts(
-    device_type: ffmpeg_next::ffi::AVHWDeviceType,
-    opts: Dictionary,
-) -> Result<*mut AVBufferRef> {
-    unsafe {
-        let mut device: *mut AVBufferRef = null_mut();
-        let ret =
-            av_hwdevice_ctx_create(&mut device, device_type, null_mut(), opts.as_mut_ptr(), 0);
         if ret < 0 {
             return Err(WaycapError::Init(format!(
                 "Failed to create hardware device: Error code {}",

--- a/src/encoders/video.rs
+++ b/src/encoders/video.rs
@@ -6,7 +6,7 @@ use crate::types::video_frame::RawVideoFrame;
 use crate::types::{config::QualityPreset, video_frame::EncodedVideoFrame};
 use crate::waycap_egl::EglContext;
 use ffmpeg_next::ffi::{av_hwdevice_ctx_create, av_hwframe_ctx_alloc, AVBufferRef};
-use ffmpeg_next::{self as ffmpeg};
+use ffmpeg_next::{self as ffmpeg, Dictionary};
 use ringbuf::HeapCons;
 
 pub const GOP_SIZE: u32 = 30;
@@ -21,8 +21,11 @@ pub trait VideoEncoder: Send {
     fn drop_encoder(&mut self);
     fn get_encoder(&self) -> &Option<ffmpeg::codec::encoder::Video>;
     fn take_encoded_recv(&mut self) -> Option<HeapCons<EncodedVideoFrame>>;
-    fn process_egl_texture(&mut self, id: u32, capture_time: i64) -> Result<()>;
-    fn enable_gl_interop_on_existing_context(&mut self, egl_ctx: &EglContext) -> Result<()>;
+    fn process_egl_texture(
+        &mut self,
+        id: u32,
+        capture_time: i64,
+    ) -> Result<()>;
 }
 
 pub fn create_hw_frame_ctx(device: *mut AVBufferRef) -> Result<*mut AVBufferRef> {
@@ -50,6 +53,25 @@ pub fn create_hw_device(device_type: ffmpeg_next::ffi::AVHWDeviceType) -> Result
             null_mut(),
             0,
         );
+        if ret < 0 {
+            return Err(WaycapError::Init(format!(
+                "Failed to create hardware device: Error code {}",
+                ret
+            )));
+        }
+
+        Ok(device)
+    }
+}
+
+pub fn create_hw_device_with_opts(
+    device_type: ffmpeg_next::ffi::AVHWDeviceType,
+    opts: Dictionary,
+) -> Result<*mut AVBufferRef> {
+    unsafe {
+        let mut device: *mut AVBufferRef = null_mut();
+        let ret =
+            av_hwdevice_ctx_create(&mut device, device_type, null_mut(), opts.as_mut_ptr(), 0);
         if ret < 0 {
             return Err(WaycapError::Init(format!(
                 "Failed to create hardware device: Error code {}",

--- a/src/pipeline/builder.rs
+++ b/src/pipeline/builder.rs
@@ -78,9 +78,8 @@ impl CaptureBuilder {
             None => QualityPreset::Medium,
         };
 
-        let mut audio_encoder = AudioEncoder::Opus;
-        if self.include_audio {
-            audio_encoder = match self.audio_encoder {
+        let audio_encoder = if self.include_audio {
+            match self.audio_encoder {
                 Some(enc) => enc,
                 None => {
                     return Err(WaycapError::Init(
@@ -88,7 +87,9 @@ impl CaptureBuilder {
                     ))
                 }
             }
-        }
+        } else {
+            AudioEncoder::Opus
+        };
 
         Capture::new(
             video_encoder,

--- a/src/types/video_frame.rs
+++ b/src/types/video_frame.rs
@@ -18,4 +18,5 @@ pub struct RawVideoFrame {
     pub stride: i32,
     pub offset: u32,
     pub size: u32,
+    pub modifier: u64,
 }

--- a/src/types/video_frame.rs
+++ b/src/types/video_frame.rs
@@ -20,3 +20,10 @@ pub struct RawVideoFrame {
     pub size: u32,
     pub modifier: u64,
 }
+
+#[derive(Debug)]
+pub struct DmaBufPlane {
+    pub fd: i32,
+    pub offset: u32,
+    pub stride: u32,
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,7 +17,7 @@ pub fn extract_dmabuf_planes(raw_frame: &RawVideoFrame) -> Result<Vec<DmaBufPlan
 pub fn calculate_dimensions(raw_frame: &RawVideoFrame) -> Result<(u32, u32)> {
     // For ARGB8888: stride = width * 4 bytes per pixel
     let width = (raw_frame.stride / 4) as u32;
-    let height = (raw_frame.size / raw_frame.stride as u32);
+    let height = raw_frame.size / raw_frame.stride as u32;
 
     if width == 0 || height == 0 {
         return Err("Invalid frame dimensions".into());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,27 @@
+use crate::types::{
+    error::Result,
+    video_frame::{DmaBufPlane, RawVideoFrame},
+};
+
+pub fn extract_dmabuf_planes(raw_frame: &RawVideoFrame) -> Result<Vec<DmaBufPlane>> {
+    match raw_frame.dmabuf_fd {
+        Some(fd) => Ok(vec![DmaBufPlane {
+            fd,
+            offset: raw_frame.offset,
+            stride: raw_frame.stride as u32,
+        }]),
+        None => Err("No DMA-BUF file descriptor in frame".into()),
+    }
+}
+
+pub fn calculate_dimensions(raw_frame: &RawVideoFrame) -> Result<(u32, u32)> {
+    // For ARGB8888: stride = width * 4 bytes per pixel
+    let width = (raw_frame.stride / 4) as u32;
+    let height = (raw_frame.size / raw_frame.stride as u32);
+
+    if width == 0 || height == 0 {
+        return Err("Invalid frame dimensions".into());
+    }
+
+    Ok((width, height))
+}

--- a/src/waycap_egl.rs
+++ b/src/waycap_egl.rs
@@ -1,0 +1,474 @@
+use std::ffi::c_void;
+
+use khronos_egl::{self as egl, ClientBuffer, Dynamic, Instance};
+
+use crate::types::video_frame::DmaBufPlane;
+
+type PFNGLEGLIMAGETARGETTEXTURE2DOESPROC =
+    unsafe extern "C" fn(target: gl::types::GLenum, image: *const c_void);
+
+pub struct EglContext {
+    egl_instance: Instance<Dynamic<libloading::Library, egl::EGL1_5>>,
+    display: egl::Display,
+    context: egl::Context,
+    surface: egl::Surface,
+    config: egl::Config,
+    dmabuf_supported: bool,
+    dmabuf_modifiers_supported: bool,
+
+    // Keep Wayland display alive
+    _wayland_display: wayland_client::Display,
+}
+
+impl EglContext {
+    pub fn new(width: i32, height: i32) -> Result<Self, egl::Error> {
+        let lib =
+            unsafe { libloading::Library::new("libEGL.so.1") }.expect("unable to find libEGL.so.1");
+        let egl_instance = unsafe { egl::DynamicInstance::<egl::EGL1_5>::load_required_from(lib) }
+            .expect("unable to load libEGL.so.1");
+
+        egl_instance.bind_api(egl::OPENGL_ES_API)?;
+
+        let wayland_display = wayland_client::Display::connect_to_env().unwrap();
+        let display =
+            unsafe { egl_instance.get_display(wayland_display.c_ptr() as *mut std::ffi::c_void) }
+                .unwrap();
+        egl_instance.initialize(display)?;
+
+        let attributes = [
+            egl::BUFFER_SIZE,
+            24,
+            egl::RENDERABLE_TYPE,
+            egl::OPENGL_BIT,
+            egl::NONE,
+            egl::NONE,
+        ];
+        let config = egl_instance
+            .choose_first_config(display, &attributes)?
+            .expect("unable to find an appropriate ELG configuration");
+
+        egl_instance.bind_api(egl::OPENGL_ES_API)?;
+
+        let context_attributes = [egl::CONTEXT_CLIENT_VERSION, 2, egl::NONE];
+
+        let context = egl_instance.create_context(display, config, None, &context_attributes)?;
+
+        let surface_attributes = [egl::WIDTH, width, egl::HEIGHT, height, egl::NONE];
+
+        let surface = egl_instance.create_pbuffer_surface(display, config, &surface_attributes)?;
+        egl_instance.make_current(display, Some(surface), Some(surface), Some(context))?;
+
+        gl::load_with(|symbol| egl_instance.get_proc_address(&symbol).unwrap() as *const _);
+
+        let (dmabuf_supported, dmabuf_modifiers_supported) =
+            Self::check_dmabuf_support(&egl_instance, display).unwrap();
+
+        log::info!("Created egl context");
+
+        Ok(Self {
+            egl_instance,
+            display,
+            config,
+            context,
+            surface,
+            dmabuf_supported,
+            dmabuf_modifiers_supported,
+
+            _wayland_display: wayland_display,
+        })
+    }
+
+    fn check_dmabuf_support(
+        egl_instance: &Instance<Dynamic<libloading::Library, egl::EGL1_5>>,
+        display: egl::Display,
+    ) -> Result<(bool, bool), Box<dyn std::error::Error>> {
+        let extensions = egl_instance.query_string(Some(display), egl::EXTENSIONS)?;
+        let ext_str = extensions.to_string_lossy();
+
+        let dmabuf_import = ext_str.contains("EGL_EXT_image_dma_buf_import");
+        let dmabuf_modifiers = ext_str.contains("EGL_EXT_image_dma_buf_import_modifiers");
+
+        if !dmabuf_import {
+            return Err("EGL_EXT_image_dma_buf_import not supported".into());
+        }
+
+        Ok((dmabuf_import, dmabuf_modifiers))
+    }
+
+    pub fn create_image_from_dmabuf(
+        &self,
+        planes: &[DmaBufPlane],
+        format: u32,
+        width: u32,
+        height: u32,
+        modifier: u64,
+    ) -> Result<egl::Image, Box<dyn std::error::Error>> {
+        if !self.dmabuf_supported {
+            return Err("DMA-BUF import not supported".into());
+        }
+
+        self.make_current()?;
+
+        let mut attributes = vec![
+            // EGL_LINUX_DRM_FOURCC_EXT
+            0x3271,
+            format as usize,
+            egl::WIDTH as usize,
+            width as usize,
+            egl::HEIGHT as usize,
+            height as usize,
+        ];
+
+        for (i, plane) in planes.iter().enumerate() {
+            let plane_attrs = match i {
+                0 => vec![
+                    // EGL_DMA_BUF_PLANE0_FD_EXT
+                    0x3272,
+                    plane.fd as usize,
+                    // EGL_DMA_BUF_PLANE0_OFFSET_EXT
+                    0x3273,
+                    plane.offset as usize,
+                    // EGL_DMA_BUF_PLANE0_PITCH_EXT
+                    0x3274,
+                    plane.stride as usize,
+                ],
+                1 => vec![
+                    // EGL_DMA_BUF_PLANE1_FD_EXT
+                    0x3275,
+                    plane.fd as usize,
+                    // EGL_DMA_BUF_PLANE1_OFFSET_EXT
+                    0x3276,
+                    plane.offset as usize,
+                    // EGL_DMA_BUF_PLANE1_PITCH_EXT
+                    0x3277,
+                    plane.stride as usize,
+                ],
+                2 => vec![
+                    // EGL_DMA_BUF_PLANE2_FD_EXT
+                    0x3278,
+                    plane.fd as usize,
+                    // EGL_DMA_BUF_PLANE2_OFFSET_EXT
+                    0x3279,
+                    plane.offset as usize,
+                    // EGL_DMA_BUF_PLANE2_PITCH_EXT
+                    0x327A,
+                    plane.stride as usize,
+                ],
+                _ => break,
+            };
+
+            attributes.extend(plane_attrs);
+
+            // Add modifiers if supported
+            if self.dmabuf_modifiers_supported {
+                let modifier_attrs = match i {
+                    0 => vec![
+                        // EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT
+                        0x3443,
+                        (modifier & 0xFFFFFFFF) as usize,
+                        // EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT
+                        0x3444,
+                        (modifier >> 32) as usize,
+                    ],
+                    1 => vec![
+                        // EGL_DMA_BUF_PLANE1_MODIFIER_LO_EXT
+                        0x3445,
+                        (modifier & 0xFFFFFFFF) as usize,
+                        // EGL_DMA_BUF_PLANE1_MODIFIER_HI_EXT
+                        0x3446,
+                        (modifier >> 32) as usize,
+                    ],
+                    2 => vec![
+                        // EGL_DMA_BUF_PLANE2_MODIFIER_LO_EXT
+                        0x3447,
+                        (modifier & 0xFFFFFFFF) as usize,
+                        // EGL_DMA_BUF_PLANE2_MODIFIER_HI_EXT
+                        0x3448,
+                        (modifier >> 32) as usize,
+                    ],
+                    _ => break,
+                };
+                attributes.extend(modifier_attrs);
+            }
+        }
+
+        attributes.push(egl::NONE as usize);
+
+        // Create EGL image
+        let image = self
+            .egl_instance
+            .create_image(
+                self.display,
+                unsafe { egl::Context::from_ptr(egl::NO_CONTEXT) },
+                // EGL_LINUX_DMA_BUF_EXT
+                0x3270,
+                unsafe { ClientBuffer::from_ptr(std::ptr::null_mut()) },
+                &attributes,
+            )
+            .map_err(|e| format!("Failed to create EGL image from DMA-BUF: {:?}", e))?;
+
+        Ok(image)
+    }
+
+    pub fn extract_pixels_from_egl_image(
+        &self,
+        image: &egl::Image,
+        width: u32,
+        height: u32,
+    ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        self.make_current()?;
+
+        unsafe {
+            // Create framebuffer and texture
+            let mut fbo = 0;
+            let mut texture = 0;
+
+            gl::GenFramebuffers(1, &mut fbo);
+            gl::GenTextures(1, &mut texture);
+
+            // Bind texture and import EGL image
+            gl::BindTexture(gl::TEXTURE_2D, texture);
+            let egl_texture_2d = {
+                let proc_name = "glEGLImageTargetTexture2DOES";
+                let proc_addr = self.egl_instance.get_proc_address(proc_name);
+
+                if proc_addr.is_none() {
+                    None
+                } else {
+                    Some(std::mem::transmute::<_, PFNGLEGLIMAGETARGETTEXTURE2DOESPROC>(proc_addr))
+                }
+            };
+
+            egl_texture_2d.unwrap()(gl::TEXTURE_2D, image.as_ptr());
+
+            // Check for GL errors after importing
+            let gl_error = gl::GetError();
+            if gl_error != gl::NO_ERROR {
+                gl::DeleteFramebuffers(1, &fbo);
+                gl::DeleteTextures(1, &texture);
+                return Err(
+                    format!("Failed to import EGL image to texture: 0x{:x}", gl_error).into(),
+                );
+            }
+
+            // Set up framebuffer
+            gl::BindFramebuffer(gl::FRAMEBUFFER, fbo);
+            gl::FramebufferTexture2D(
+                gl::FRAMEBUFFER,
+                gl::COLOR_ATTACHMENT0,
+                gl::TEXTURE_2D,
+                texture,
+                0,
+            );
+
+            // Check framebuffer status
+            let status = gl::CheckFramebufferStatus(gl::FRAMEBUFFER);
+            if status != gl::FRAMEBUFFER_COMPLETE {
+                gl::DeleteFramebuffers(1, &fbo);
+                gl::DeleteTextures(1, &texture);
+                gl::BindFramebuffer(gl::FRAMEBUFFER, 0);
+                return Err(format!("Framebuffer not complete: 0x{:x}", status).into());
+            }
+
+            // Set viewport
+            gl::Viewport(0, 0, width as i32, height as i32);
+
+            // Allocate pixel buffer (RGBA format)
+            let pixel_count = (width * height * 4) as usize;
+            let mut pixels = vec![0u8; pixel_count];
+
+            // Read pixels from framebuffer
+            gl::ReadPixels(
+                0,
+                0,                 // x, y offset
+                width as i32,      // width
+                height as i32,     // height
+                gl::RGBA,          // format
+                gl::UNSIGNED_BYTE, // type
+                pixels.as_mut_ptr() as *mut std::ffi::c_void,
+            );
+
+            // Check for read errors
+            let gl_error = gl::GetError();
+            if gl_error != gl::NO_ERROR {
+                gl::DeleteFramebuffers(1, &fbo);
+                gl::DeleteTextures(1, &texture);
+                gl::BindFramebuffer(gl::FRAMEBUFFER, 0);
+                return Err(format!("Failed to read pixels: 0x{:x}", gl_error).into());
+            }
+
+            // Cleanup
+            gl::BindFramebuffer(gl::FRAMEBUFFER, 0);
+            gl::DeleteFramebuffers(1, &fbo);
+            gl::DeleteTextures(1, &texture);
+
+            Ok(pixels)
+        }
+    }
+
+    pub fn save_pixels_as_png(
+        pixels: &[u8],
+        width: u32,
+        height: u32,
+        filename: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        use image::{ImageBuffer, RgbaImage};
+
+        let img: RgbaImage = ImageBuffer::from_raw(width, height, pixels.to_vec())
+            .ok_or("Failed to create image buffer")?;
+
+        img.save(filename)?;
+        Ok(())
+    }
+
+    pub fn bind_image_to_texture(
+        &self,
+        image: egl::Image,
+    ) -> Result<u32, Box<dyn std::error::Error>> {
+        self.make_current()?;
+
+        let mut texture_id = 0;
+        unsafe {
+            gl::GenTextures(1, &mut texture_id);
+
+            // Try GL_TEXTURE_2D first
+            gl::BindTexture(gl::TEXTURE_2D, texture_id);
+
+            // Load the extension function
+
+            let egl_texture_2d = {
+                let proc_name = "glEGLImageTargetTexture2DOES";
+                let proc_addr = self.egl_instance.get_proc_address(proc_name);
+
+                if proc_addr.is_none() {
+                    None
+                } else {
+                    Some(std::mem::transmute::<_, PFNGLEGLIMAGETARGETTEXTURE2DOESPROC>(proc_addr))
+                }
+            };
+
+            egl_texture_2d.unwrap()(gl::TEXTURE_2D, image.as_ptr());
+
+            if gl::GetError() == gl::NO_ERROR {
+                let mut width = 0;
+                gl::GetTexLevelParameteriv(gl::TEXTURE_2D, 0, gl::TEXTURE_WIDTH, &mut width);
+                if width == 0 {
+                    log::warn!("Texture has zero width after bind");
+                }
+
+                gl::BindTexture(gl::TEXTURE_2D, 0);
+
+                log::info!(
+                    "✓ Bound EGL image to GL_TEXTURE_2D: {}",
+                    texture_id
+                );
+                return Ok(texture_id);
+            }
+
+            // Fallback to GL_TEXTURE_EXTERNAL_OES
+            // TEXTURE_EXTERNAL_OES
+            gl::BindTexture(0x8D65, texture_id);
+            egl_texture_2d.unwrap()(0x8D65, image.as_ptr());
+            gl::BindTexture(0x8D65, 0);
+
+            if gl::GetError() != gl::NO_ERROR {
+                gl::DeleteTextures(1, &texture_id);
+                return Err("Failed to bind EGL image to texture".into());
+            }
+
+            log::info!(
+                "✓ Bound EGL image to GL_TEXTURE_EXTERNAL_OES: {}",
+                texture_id
+            );
+        }
+
+        Ok(texture_id)
+    }
+
+    pub fn destroy_image(&self, image: egl::Image) -> Result<(), Box<dyn std::error::Error>> {
+        self.egl_instance
+            .destroy_image(self.display, image)
+            .map_err(|e| format!("Failed to destroy EGL image: {:?}", e).into())
+    }
+
+    pub fn delete_texture(&self, texture_id: u32) {
+        unsafe {
+            gl::DeleteTextures(1, &texture_id);
+        }
+    }
+
+    pub fn make_current(&self) -> Result<(), egl::Error> {
+        self.egl_instance.make_current(
+            self.display,
+            Some(self.surface),
+            Some(self.surface),
+            Some(self.context),
+        )?;
+        Ok(())
+    }
+
+    pub fn get_egl_instance(&self) -> &Instance<Dynamic<libloading::Library, egl::EGL1_5>> {
+        &self.egl_instance
+    }
+
+    pub fn get_display(&self) -> egl::Display {
+        self.display
+    }
+
+    pub fn test_opengl(&self) -> Result<(), Box<dyn std::error::Error>> {
+        self.make_current()?;
+
+        let version = unsafe {
+            let data = gl::GetString(gl::VERSION) as *const i8;
+            if data.is_null() {
+                "Unknown".to_string()
+            } else {
+                std::ffi::CStr::from_ptr(data)
+                    .to_string_lossy()
+                    .into_owned()
+            }
+        };
+        log::info!("OpenGL Version: {}", version);
+
+        let renderer = unsafe {
+            let data = gl::GetString(gl::RENDERER) as *const i8;
+            if data.is_null() {
+                "Unknown".to_string()
+            } else {
+                std::ffi::CStr::from_ptr(data)
+                    .to_string_lossy()
+                    .into_owned()
+            }
+        };
+        log::info!("OpenGL Renderer: {}", renderer);
+
+        // Test texture creation
+        let mut texture_id = 0;
+        unsafe {
+            gl::GenTextures(1, &mut texture_id);
+            if texture_id != 0 {
+                println!("✓ Texture created: ID {}", texture_id);
+                gl::DeleteTextures(1, &texture_id);
+            } else {
+                return Err("Failed to create texture".into());
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for EglContext {
+    fn drop(&mut self) {
+        let _ = self
+            .egl_instance
+            .make_current(self.display, None, None, None);
+        let _ = self
+            .egl_instance
+            .destroy_surface(self.display, self.surface);
+        let _ = self
+            .egl_instance
+            .destroy_context(self.display, self.context);
+        let _ = self.egl_instance.terminate(self.display);
+    }
+}


### PR DESCRIPTION
Implemented a no CPU Copy approach for nvidia encoding and capture/

The pipeline for nvenc looks like this:
- DMA Buffer is passed to an EGL context and mapped to a GL Texture
- This texture is mapped to CUDA memory
- This is then mapped to a CUDA AVFrame
- AVFrame is sent to ffmpeg to encode

Nvenc encoder creates a shared CUDA context using the curt crate and I also had to add some FFI bindings for GL Interoperability

Also added clippy and new git hub action to enforce no warnings