### PR TITLE
Remove push trigger from Clippy workflow to run only on PRs

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,7 +1,5 @@
 name: Clippy Check
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:


### PR DESCRIPTION
Removed redundant Clippy execution that was running on both Pull Requests and pushes to main branch.
This solves issue #11 