### PR TITLE
Discard frames in drain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,3 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This library was extracted from the [WayCap](https://github.com/Adonca2203/WayCap) project to provide a reusable screen capture solution
 - Designed for low-latency screen recording applications
 - Optimized for Wayland desktop environments on Linux
+
+## [1.0.1] - 2025-07-11
+### Changed
+- `finish()` now discards remaining frames in encoder buffers instead of sending them to receivers, preventing channel overflow errors

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "waycap-rs"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bytemuck",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waycap-rs"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Adonis Carvajal <adonis.carvajal2203@gmail.com>"]
 description = "High-level Wayland screen capture library with hardware-accelerated encoding"

--- a/src/encoders/vaapi_encoder.rs
+++ b/src/encoders/vaapi_encoder.rs
@@ -169,27 +169,7 @@ impl VideoEncoder for VaapiEncoder {
             // Drain encoder
             encoder.send_eof()?;
             let mut packet = ffmpeg::codec::packet::Packet::empty();
-            while encoder.receive_packet(&mut packet).is_ok() {
-                if let Some(data) = packet.data() {
-                    match self.encoded_frame_sender.try_send(EncodedVideoFrame {
-                        data: data.to_vec(),
-                        is_keyframe: packet.is_key(),
-                        pts: packet.pts().unwrap_or(0),
-                        dts: packet.dts().unwrap_or(0),
-                    }) {
-                        Ok(_) => {}
-                        Err(crossbeam::channel::TrySendError::Full(_)) => {
-                            log::error!("Could not send encoded video frame. Receiver is full");
-                        }
-                        Err(crossbeam::channel::TrySendError::Disconnected(_)) => {
-                            log::error!(
-                                "Cound not send encoded video frame. Receiver disconnected"
-                            );
-                        }
-                    }
-                };
-                packet = ffmpeg::codec::packet::Packet::empty();
-            }
+            while encoder.receive_packet(&mut packet).is_ok() {} // Discard these frames
         }
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,7 +342,7 @@ impl Capture {
     }
 
     /// Stop recording and drain the encoders of any last frames they have in their internal
-    /// buffers
+    /// buffers. These frames are discarded.
     pub fn finish(&mut self) -> Result<()> {
         self.pause_flag.store(true, Ordering::Release);
         self.video_encoder.lock().unwrap().drain()?;


### PR DESCRIPTION
Bugfix: Discard remaining frames when calling drain() on encoders

When calling the drain function on encoders, the remaining frames in their buffers are now discarded. This ensures that we do not keep trying to push encoded frames to the receiver which may no longer be consumed, as the end user likely assumes finish() means stop.

If the end user assumes finish() == stop and stops receiving frames (like in one of the examples), errors are thrown as the channel gets full.

Fixes "Receiver is full" errors during capture finish process.