### PR TITLE
Allo multiple consumers for encoded frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,3 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.2] - 2025-07-13
 ### Changed
 - Pipewire logging is now debug for the `core` logs.
+
+## [2.0.0] - 2025-07-14
+### Breaking Changes
+- Renamed `take_video_receiver` to `get_video_receiver`
+- Renamed `take_audio_receiver` to `get_audio_receiver`
+- These now return a copy to the channel instead of give ownership allowing multiple consumers to receive the frames

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "waycap-rs"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waycap-rs"
-version = "1.0.2"
+version = "2.0.0"
 edition = "2021"
 authors = ["Adonis Carvajal <adonis.carvajal2203@gmail.com>"]
 description = "High-level Wayland screen capture library with hardware-accelerated encoding"

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     capture.start()?;
     
     // Get receivers for encoded frames
-    let video_receiver = capture.take_video_receiver();
-    let audio_receiver = capture.take_audio_receiver()?;
+    let video_receiver = capture.get_video_receiver();
+    let audio_receiver = capture.get_audio_receiver()?;
     
     // Process frames in separate threads
     let video_thread = thread::spawn(move || {

--- a/examples/record_and_save.rs
+++ b/examples/record_and_save.rs
@@ -29,7 +29,7 @@ fn main() -> Result<()> {
         .with_cursor_shown()
         .build()?;
 
-    let video_recv = capture.take_video_receiver();
+    let video_recv = capture.get_video_receiver();
 
     // Use a BTree Map so it is sorted by DTS
     // needed like this for export time monotonic dts times

--- a/src/encoders/audio.rs
+++ b/src/encoders/audio.rs
@@ -15,7 +15,7 @@ pub trait AudioEncoder: Send {
     fn drain(&mut self) -> Result<()>;
     fn reset(&mut self) -> Result<()>;
     fn get_encoder(&self) -> &Option<ffmpeg_next::codec::encoder::Audio>;
-    fn take_encoded_recv(&mut self) -> Option<Receiver<EncodedAudioFrame>>;
+    fn get_encoded_recv(&mut self) -> Option<Receiver<EncodedAudioFrame>>;
     fn drop_encoder(&mut self);
 }
 

--- a/src/encoders/nvenc_encoder.rs
+++ b/src/encoders/nvenc_encoder.rs
@@ -225,8 +225,8 @@ impl VideoEncoder for NvencEncoder {
         self.encoder.take();
     }
 
-    fn take_encoded_recv(&mut self) -> Option<Receiver<EncodedVideoFrame>> {
-        self.encoded_frame_recv.take()
+    fn get_encoded_recv(&mut self) -> Option<Receiver<EncodedVideoFrame>> {
+        self.encoded_frame_recv.clone()
     }
 }
 

--- a/src/encoders/opus_encoder.rs
+++ b/src/encoders/opus_encoder.rs
@@ -157,7 +157,7 @@ impl AudioEncoder for OpusEncoder {
         Ok(())
     }
 
-    fn take_encoded_recv(&mut self) -> Option<Receiver<EncodedAudioFrame>> {
-        self.encoded_samples_recv.take()
+    fn get_encoded_recv(&mut self) -> Option<Receiver<EncodedAudioFrame>> {
+        self.encoded_samples_recv.clone()
     }
 }

--- a/src/encoders/vaapi_encoder.rs
+++ b/src/encoders/vaapi_encoder.rs
@@ -195,8 +195,8 @@ impl VideoEncoder for VaapiEncoder {
         self.filter_graph.take();
     }
 
-    fn take_encoded_recv(&mut self) -> Option<Receiver<EncodedVideoFrame>> {
-        self.encoded_frame_recv.take()
+    fn get_encoded_recv(&mut self) -> Option<Receiver<EncodedVideoFrame>> {
+        self.encoded_frame_recv.clone()
     }
 }
 

--- a/src/encoders/video.rs
+++ b/src/encoders/video.rs
@@ -20,7 +20,7 @@ pub trait VideoEncoder: Send {
     fn reset(&mut self) -> Result<()>;
     fn drop_encoder(&mut self);
     fn get_encoder(&self) -> &Option<ffmpeg::codec::encoder::Video>;
-    fn take_encoded_recv(&mut self) -> Option<Receiver<EncodedVideoFrame>>;
+    fn get_encoded_recv(&mut self) -> Option<Receiver<EncodedVideoFrame>>;
 
     fn as_any(&self) -> &dyn Any;
 }


### PR DESCRIPTION
We already use crossbeam channels for receivers, these can be used with multiple consumers so enabled that functionality and renamed function to better represent the behavior.