### PR TITLE
Enhance compatibility for some GPUs

### DIFF
--- a/src/waycap_egl.rs
+++ b/src/waycap_egl.rs
@@ -106,7 +106,7 @@ impl EglContext {
         let (dmabuf_supported, dmabuf_modifiers_supported) =
             Self::check_dmabuf_support(&egl_instance, display).unwrap();
 
-        let gpu_vendor = GpuVendor::from(egl_instance.query_string(Some(display), egl::VENDOR)?);
+            let gpu_vendor = get_gpu_vendor();
 
         Ok(Self {
             egl_instance,
@@ -448,6 +448,18 @@ impl Drop for EglContext {
         let _ = self.egl_instance.terminate(self.display);
         if let Some(texture) = self.persistent_texture_id.get() {
             self.delete_texture(texture);
+        }
+    }
+}
+
+fn get_gpu_vendor() -> GpuVendor {
+    unsafe {
+        let vendor_ptr = gl::GetString(gl::VENDOR);
+        if vendor_ptr.is_null() {
+            GpuVendor::UNKNOWN
+        } else {
+            let vendor = CStr::from_ptr(vendor_ptr as *const std::ffi::c_char);
+            GpuVendor::from(vendor)
         }
     }
 }


### PR DESCRIPTION
There's two main changes:

1. Use `GL_VENDOR` instead of `EGL_VENDOR` which is better for vendor checking.
    > Sometimes `"Mesa Project"` will be returned by `EGL_VENDOR`. (For example on my laptop, a thinkbook with AMD GPU, archlinux, KDE Plasma)

2. Fallback to use surfaceless mode once pbuffer is not supported. It's also a problem occurs on my laptop.

I've tested it using example `record_and_save`, maybe you should test it again so that I don't mess anything.