### PR TITLE
docs: fix README example imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ crossbeam = "0.8.4"
 
 ## Example Usage
 ```rust
-use waycap_rs::{CaptureBuilder, QualityPreset, VideoEncoder, AudioEncoder};
 use std::{thread, time::Duration};
+use waycap_rs::pipeline::builder::CaptureBuilder;
+use waycap_rs::types::config::{AudioEncoder, QualityPreset, VideoEncoder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a capture session


### PR DESCRIPTION
## Summary
- update the README example to use the public import paths that match the crate API
- keep the example consistent with the crate-level docs

Closes #20.
