### PR TITLE
fix: #35 missing config for non-nvidia

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,7 @@
 fn main() {
     // CUDA FFI bindings
+		#[cfg(feature = "nvidia")]
     println!("cargo:rustc-link-lib=dylib=cuda");
+
     println!("cargo:rustc-link-search=native=/usr/lib");
 }


### PR DESCRIPTION
As per https://github.com/Adonca2203/waycap-rs/issues/35#issuecomment-4661402330